### PR TITLE
Compatibility improvements

### DIFF
--- a/lib/disassembler.py
+++ b/lib/disassembler.py
@@ -82,7 +82,8 @@ class Disassembler():
 
 
     def load_dyn_sym(self):
-        rel = self.elf.get_section_by_name(b".rela.plt")
+        rel = (self.elf.get_section_by_name(b".rela.plt") or
+                self.elf.get_section_by_name(b".rel.plt"))
         dyn = self.elf.get_section_by_name(b".dynsym")
 
         relitems = list(rel.iter_relocations())

--- a/reverse.py
+++ b/reverse.py
@@ -105,7 +105,7 @@ if __name__ == '__main__':
 
     dis = Disassembler(filename)
 
-    if addr[:2] == "0x":
+    if addr.startswith("0x"):
         addr = int(addr, 16)
     else:
         try:

--- a/reverse.py
+++ b/reverse.py
@@ -1,4 +1,4 @@
-#!/bin/python3
+#!/usr/bin/env python3
 #
 # Reverse : reverse engineering for x86 binaries
 # Copyright (C) 2015    Joel


### PR DESCRIPTION
The tests didn't run on Debian GNU/Linux, since the shebang explicitly used `/bin/python`, so I changed it to the more portable `/usr/bin/env python`. Also, some binaries doesn't have section `.rela.plt`, but rather `.rel.plt`, so if former is not found, the `or` operator makes sure to check for latter as well.