### PR TITLE
Improved exception handling

### DIFF
--- a/lib/ast.py
+++ b/lib/ast.py
@@ -68,7 +68,7 @@ class Ast_IfGoto:
         try:
             c = addr_color[self.addr_jump]
             print(color("0x%x ", c) % self.addr_jump)
-        except:
+        except KeyError:
             print("0x%x " % self.addr_jump)
 
 

--- a/lib/binary.py
+++ b/lib/binary.py
@@ -41,10 +41,10 @@ class Binary(object):
 
         try:
             self.__binary = lib.elf.ELF(self, filename)
-        except:
+        except Exception:
             try:
                 self.__binary = lib.pe.PE(self, filename)
-            except:
+            except Exception:
                 die("the file is not PE or ELF binary")
 
         self.__binary.load_static_sym()

--- a/lib/disassembler.py
+++ b/lib/disassembler.py
@@ -71,10 +71,7 @@ class Disassembler():
             if opt_addr.startswith("0x"):
                 a = int(opt_addr, 16)
             else:
-                try:
-                    a = self.binary.symbols[s]
-                except:
-                    a = -1
+                a = self.binary.symbols.get(s, -1)
 
             if a != -1:
                 found = True

--- a/lib/disassembler.py
+++ b/lib/disassembler.py
@@ -183,7 +183,7 @@ class Disassembler():
 
             try:
                 curr = self.code[rest.pop()]
-            except:
+            except IndexError:
                 break
 
         return gph

--- a/lib/elf.py
+++ b/lib/elf.py
@@ -52,11 +52,8 @@ class ELF:
 
     def load_static_sym(self):
         symtab = self.elf.get_section_by_name(b".symtab")
-        try:
-            if symtab == None:
-                return
-        except:
-            pass
+        if symtab is None:
+            return
         for sy in symtab.iter_symbols():
             if sy.entry.st_value != 0 and sy.name != b"":
                 self.classbinary.reverse_symbols[sy.entry.st_value] = sy.name.decode()
@@ -94,12 +91,8 @@ class ELF:
 
 
     def is_rodata(self, addr):
-        # exception if rodata != None
-        try:
-            if self.rodata == None:
-                return False
-        except:
-            pass
+        if self.rodata is None:
+            return False
         start = self.rodata.header.sh_addr
         end = start + self.rodata.header.sh_size
         return  start <= addr <= end

--- a/lib/generate_ast.py
+++ b/lib/generate_ast.py
@@ -396,7 +396,7 @@ def extract_loop_paths(paths):
         try:
             idx = seen[el[0]]
             group_endloop[idx].append(el)
-        except:
+        except KeyError:
             seen[el[0]] = len(group_endloop)
             group_endloop.append([el])
 
@@ -423,7 +423,7 @@ def extract_loop_paths(paths):
                     # is it possible to have a conditional jump here ?
                     # if true, need to check BRANCH_NEXT_JUMP
                     no_jump[i] = gph.link_out[queue][BRANCH_NEXT]
-                except:
+                except KeyError:
                     no_jump[i] = -1
                 all_jmp = False
 

--- a/lib/graph.py
+++ b/lib/graph.py
@@ -112,7 +112,7 @@ class Graph:
             for k, lst_i in self.link_in.items():
                 try:
                     lst_i[lst_i.index(curr)] = pred
-                except:
+                except ValueError:
                     pass
 
 

--- a/lib/output.py
+++ b/lib/output.py
@@ -241,7 +241,7 @@ def print_inst(i, tab=0, prefix=""):
         try:
             addr = i.operands[0].value.imm
             print(i.mnemonic + " " + color("0x%x" % addr, addr_color[addr]))
-        except:
+        except Exception:
             print(i.mnemonic + " 0x%x" % addr)
         return
 

--- a/lib/output.py
+++ b/lib/output.py
@@ -273,10 +273,7 @@ def print_inst(i, tab=0, prefix=""):
 
 def print_ast(entry, ast):
     print_no_end(color_keyword("function "))
-    try:
-        print_no_end(binary.reverse_symbols[entry])
-    except:
-        print_no_end("0x%x" % entry)
+    print_no_end(binary.reverse_symbols.get(entry, hex(entry)))
     print(" {")
     print_vars_type()
     ast.print(1)

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -80,10 +80,7 @@ OPPOSITES = [
 OPPOSITES = dict(OPPOSITES + [i[::-1] for i in OPPOSITES])
 
 def invert_cond(ty):
-    try:
-        return OPPOSITES[ty]
-    except:
-        return -1
+    return OPPOSITES.get(ty, -1)
 
 
 def cond_inst_str(ty):
@@ -144,13 +141,8 @@ def cond_sign_str(ty, has_cmp=False):
         X86_INS_JS: "<"
     }
 
-    try:
-        if has_cmp:
-            return conds_cmp[ty]
-        else:
-            return conds[ty]
-    except:
-        return "UNKNOWN"
+    c = conds_cmp if has_cmp else conds
+    return c.get(ty, "UNKNOWN")
 
     # TODO : invert_cond need to be updated too
     # X86_INS_JAE


### PR DESCRIPTION
I removed all catch-all except clauses (e.g. those that doesn't specify a base class like `except:`) and replaced them with either a base class that doesn't catch exceptions like `KeyboardInterrupt` which should never be caught by an application, or other constructions such as `dict.get` and proper equality check w.r.t `None`.