### PR TITLE
added IDIV instruction decoding

### DIFF
--- a/lib/output.py
+++ b/lib/output.py
@@ -265,6 +265,12 @@ def print_inst(i, tab=0, prefix=""):
             print_no_end(" " + cond_sign_str(i.id) + " ")
             print_operand(i, 1)
         modified = True
+    elif i.id == X86_INS_IDIV:
+        print_no_end('eax = edx:eax / ')
+        print_operand(i, 0)
+        print_no_end('; edx = edx:eax % ')
+        print_operand(i, 0)
+        modified = True
     else:
         print_no_end("%s " % i.mnemonic)
         if len(i.operands) > 0:


### PR DESCRIPTION
Since it puts the remainder and the quotient into two separate registers, I could only translate it into two C instructions separated by a semicolon. If you have a better idea, feel free to edit.