### PR TITLE
RIP-relative addressing improvements

### DIFF
--- a/lib/output.py
+++ b/lib/output.py
@@ -113,7 +113,9 @@ def print_operand(i, num_op, hexa=False):
                 print_no_end(color_var(get_var_name(i, num_op)))
                 return True
             elif mm.base == X86_REG_RIP or mm.base == X86_REG_EIP:
-                print_no_end("*(" + hex(i.address + i.size + mm.disp) + ")")
+                addr = i.address + i.size + mm.disp
+                print_no_end("*({0})".format(
+                    binary.reverse_symbols.get(addr, hex(addr))))
                 return True
 
         printed = False

--- a/lib/output.py
+++ b/lib/output.py
@@ -113,7 +113,7 @@ def print_operand(i, num_op, hexa=False):
                 print_no_end(color_var(get_var_name(i, num_op)))
                 return True
             elif mm.base == X86_REG_RIP or mm.base == X86_REG_EIP:
-                print_no_end("*(" + hex(i.address + mm.disp) + ")")
+                print_no_end("*(" + hex(i.address + i.size + mm.disp) + ")")
                 return True
 
         printed = False

--- a/tests/server_connection_handler.rev
+++ b/tests/server_connection_handler.rev
@@ -58,7 +58,7 @@ function connection_handler {
     if (var5 == 0) {
         0x400bde: edi = 0x400dc6 "Client disconnected" # mov edi, 0x400dc6
         0x400be3: call 0x400800 <puts@plt>
-        0x400be8: rax = *(0x6012a8) # mov rax, qword ptr [rip + 0x2006b9]
+        0x400be8: rax = *(__TMC_END__) # mov rax, qword ptr [rip + 0x2006b9]
         0x400bef: rdi = rax # mov rdi, rax
         0x400bf2: call 0x400870 <fflush@plt>
         0x400bf7: jmp 0x400c09

--- a/tests/server_connection_handler.rev
+++ b/tests/server_connection_handler.rev
@@ -58,7 +58,7 @@ function connection_handler {
     if (var5 == 0) {
         0x400bde: edi = 0x400dc6 "Client disconnected" # mov edi, 0x400dc6
         0x400be3: call 0x400800 <puts@plt>
-        0x400be8: rax = *(0x6012a1) # mov rax, qword ptr [rip + 0x2006b9]
+        0x400be8: rax = *(0x6012a8) # mov rax, qword ptr [rip + 0x2006b9]
         0x400bef: rdi = rax # mov rdi, rax
         0x400bf2: call 0x400870 <fflush@plt>
         0x400bf7: jmp 0x400c09


### PR DESCRIPTION
I improved decoding memory operations using RIP-relative addressing by
 - fixing a bug that caused the destination to be off by the length of the instruction and
 - adding symbol resolution for such addresses.

The modified testcases match the output of the `disasm` command in GDB w.r.t addresses; the symbol in `server_connection_handler` differs, if you have any idea how GDB resolves it as `stdout` while Reverse emits `__TMC_END__`, I'd be interested.