### PR TITLE
Alternative test harness

### DIFF
--- a/reverse.py
+++ b/reverse.py
@@ -34,7 +34,7 @@ from lib.vim import generate_vim_syntax
 
 
 
-def reverse():
+def reverse(argv=None):
     # Parse arguments
     parser = ArgumentParser(description=
         'Reverse engineering for x86 binaries. Generation of pseudo-C. '
@@ -73,7 +73,7 @@ def reverse():
     parser.add_argument('--forcejmp', action='store_true',
             help=('Try to disassemble if a "jmp [ADDR]" or jmp rax is found.'))
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     lib.utils.dbg                         = args.opt_debug
     lib.disassembler.forcejmp             = args.forcejmp

--- a/test_reverse.py
+++ b/test_reverse.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+from contextlib import redirect_stdout
+from nose.tools import assert_equal
+from pathlib import Path
+from io import StringIO
+
+from reverse import reverse
+import lib.ast
+
+TESTS = Path('tests')
+
+SYMBOLS = {
+        TESTS / 'server.bin': ["main", "connection_handler"],
+        TESTS / 'pendu.bin': ["_main", "___main"]
+        }
+
+def test_revese():
+    for p in TESTS.glob('*.bin'):
+        for symbol in sorted(SYMBOLS.get(p, [None])):
+            yield reverse_file, str(p), symbol
+
+def reverse_file(filename, symbol):
+    # FIXME horrible hack to deal with global variables
+    lib.ast.local_vars_idx = {}
+    lib.ast.local_vars_size = []
+    lib.ast.local_vars_name = []
+    lib.ast.vars_counter = 1
+    lib.ast.cmp_fused = set()
+    sio = StringIO()
+    params = ['--nosectionsname', '--nocolor', filename]
+    if symbol is not None:
+        params.insert(0, '-x')
+        params.insert(1, symbol)
+    with redirect_stdout(sio):
+        reverse(params)
+    postfix = '{0}.rev'.format('' if symbol is None else '_' + symbol)
+    with open(filename.replace('.bin', postfix)) as f:
+        assert_equal(sio.getvalue(), f.read())


### PR DESCRIPTION
This one performs the same tests as the current one, but uses a single Python process, thus
 - it performs twice as fast as `make -j` on my machine (avoids 56 Python + shell processes),
 - it prints much less by default, making it easy to spot, what went wrong or if everything's OK and
 - it can provide some practical benefits such as code coverage report.

I didn't delete the original implementation, since right now I think it doesn't replace but rather complements that. It's fast enough to run quite frequently, while the Makefile can be used for compilation and pre-push testing.

The only dependency over a standard Python 3.4 setup is [nose][1].

  [1]: https://nose.readthedocs.org/en/latest/