### PR TITLE
decode AND dest, 0 as dest = 0

### DIFF
--- a/lib/output.py
+++ b/lib/output.py
@@ -286,6 +286,10 @@ def print_inst(i, tab=0, prefix=""):
                 i.operands[1].value.imm == -1):
             print_no_end(" = -1")
 
+        elif (i.id == X86_INS_AND and i.operands[1].type == X86_OP_IMM and
+                i.operands[1].value.imm == 0):
+            print_no_end(" = 0")
+
         elif (all(op.type == X86_OP_REG for op in i.operands) and
                 len(set(op.value.reg for op in i.operands)) == 1 and
                 i.id == X86_INS_XOR):


### PR DESCRIPTION
Same as 436a9c3, but with AND and 0, I found it in Visual Studio 2010+ PE binaries.

Before:

    0x546e73: *(ecx + 12) &= 0 # and dword ptr [ecx + 0xc], 0

After:

    0x546e73: *(ecx + 12) = 0 # and dword ptr [ecx + 0xc], 0