### PR TITLE
fuse XOR, AND, OR instructions with jumps

### DIFF
--- a/lib/ast.py
+++ b/lib/ast.py
@@ -20,7 +20,8 @@
 from lib.utils import invert_cond, is_call, is_uncond_jump, BRANCH_NEXT
 from lib.colors import pick_color, addr_color, color, color_keyword
 from lib.output import (print_block, print_if_cond, print_cmp_jump_commented,
-        print_comment, print_no_end, print_tabbed, print_tabbed_no_end)
+        print_comment, print_no_end, print_tabbed, print_tabbed_no_end,
+        ASSIGNMENT_OPS)
 from capstone.x86 import (X86_INS_CMP, X86_INS_MOV, X86_INS_TEST, X86_OP_IMM,
         X86_OP_INVALID, X86_OP_REG, X86_REG_EBP, X86_REG_RBP)
 
@@ -38,6 +39,9 @@ vars_counter = 1
 # If an address of a cmp is here, it means that we have fused 
 # with an if, so don't print this instruction.
 cmp_fused = set()
+
+FUSE_OPS = set(ASSIGNMENT_OPS)
+FUSE_OPS.add(X86_INS_CMP)
 
 
 class Ast_Branch:
@@ -259,7 +263,7 @@ def fuse_cmp_if(ast):
         types_ast = (Ast_Ifelse, Ast_IfGoto, Ast_AndIf)
         for i, n in enumerate(ast.nodes):
             if isinstance(n, list):
-                if ((n[-1].id == X86_INS_CMP or (n[-1].id == X86_INS_TEST and
+                if ((n[-1].id in FUSE_OPS or (n[-1].id == X86_INS_TEST and
                     all(op.type == X86_OP_REG for op in n[-1].operands) and
                     len(set(op.value.reg for op in n[-1].operands)) == 1))
                     and i+1 < len(ast.nodes)

--- a/lib/output.py
+++ b/lib/output.py
@@ -37,6 +37,8 @@ binary = None
 nocomment = False
 nosectionsname = False
 
+ASSIGNMENT_OPS = {X86_INS_XOR, X86_INS_AND, X86_INS_OR}
+
 
 def print_block(blk, tab):
     for i in blk:
@@ -205,12 +207,22 @@ def print_cmp_jump_commented(cmp_inst, jump_inst, tab):
 
 
 def print_if_cond(cmp_inst, jump_id):
+    assignment = cmp_inst != None and cmp_inst.id in ASSIGNMENT_OPS
     if cmp_inst != None:
+        if assignment:
+            print_no_end("(")
         print_no_end("(")
         print_operand(cmp_inst, 0)
         print_no_end(" ")
 
     if cmp_inst != None and cmp_inst.id == X86_INS_TEST:
+        print_no_end(inst_symbol(jump_id, True))
+        print_no_end(" 0)")
+    elif assignment:
+        print_no_end(inst_symbol(cmp_inst.id))
+        print_no_end(" ")
+        print_operand(cmp_inst, 1)
+        print_no_end(") ")
         print_no_end(inst_symbol(jump_id, True))
         print_no_end(" 0)")
     else:

--- a/tests/canary_plt.rev
+++ b/tests/canary_plt.rev
@@ -19,9 +19,9 @@ function main {
     }
     0x400565: eax = 0 # mov eax, 0
     0x40056a: rdx = var1_canary # mov rdx, qword ptr [rbp - 8]
-    0x40056e: rdx ^= *(fs + 40) # xor rdx, qword ptr fs:[0x28]
+    # 0x40056e: xor rdx, qword ptr fs:[0x28]
     # 0x400577: je 0x40057e
-    if != {
+    if ((rdx ^= *(fs + 40)) != 0) {
         0x400579: call 0x400400 <__stack_chk_fail@plt>
     }
     0x40057e: leave 


### PR DESCRIPTION
See test diff for example, further instructions can be added to `ASSIGNMENT_OPS` in `lib/output.py`, as it gets imported into `lib/ast.py` as well.